### PR TITLE
Update build_gromacs_5.1.4_gcc6_ivybrg.md

### DIFF
--- a/GROMACS/build_gromacs_5.1.4_gcc6_ivybrg.md
+++ b/GROMACS/build_gromacs_5.1.4_gcc6_ivybrg.md
@@ -62,7 +62,7 @@ prefix to somewhere you have permission to write to.
 cmake ../ -DGMX_MPI=ON -DGMX_OPENMP=ON -DGMX_GPU=OFF -DGMX_X11=OFF -DGMX_DOUBLE=OFF \
           -DCMAKE_C_FLAGS="$FLAGS" -DCMAKE_CXX_FLAGS="$FLAGS" -DGMX_BUILD_MDRUN_ONLY=ON  \
           -DFFTWF_INCLUDE_DIR=/opt/cray/fftw/3.3.4.9/ivybridge/include \
-          -DCMAKE_INSTALL_PREFIX=/work/y07/y07/gmx/5.0.5-phase2
+          -DCMAKE_INSTALL_PREFIX=/work/y07/y07/gmx/5.1.4
 make -j 8 install
 ```
 
@@ -94,7 +94,7 @@ prefix to somewhere you have permission to write to.
 cmake ../ -DGMX_MPI=ON -DGMX_OPENMP=ON -DGMX_GPU=OFF -DGMX_X11=OFF -DGMX_DOUBLE=ON \
           -DCMAKE_C_FLAGS="$FLAGS" -DCMAKE_CXX_FLAGS="$FLAGS" -DGMX_BUILD_MDRUN_ONLY=ON  \
           -DFFTWF_INCLUDE_DIR=/opt/cray/fftw/3.3.4.9/ivybridge/include \
-          -DCMAKE_INSTALL_PREFIX=/work/y07/y07/gmx/5.4.1-phase2
+          -DCMAKE_INSTALL_PREFIX=/work/y07/y07/gmx/5.1.4
 make -j 8 install
 ```
 


### PR DESCRIPTION
Minor typos fixed in GROMACS parallel build instructions. 